### PR TITLE
Add back default property for webpack require

### DIFF
--- a/src/index.cts
+++ b/src/index.cts
@@ -212,7 +212,9 @@ export class TransformAsyncModulesPlugin implements WebpackPluginInstance {
 
   #addDependenciesToModule(module: Module) {
     for (const [request, identifier] of this.#dependencies.entries()) {
-      module.addDependency(new TransformAsyncDependency(request, identifier));
+      module.addDependency(
+        new TransformAsyncDependency(request, identifier, ["default"]),
+      );
     }
   }
 


### PR DESCRIPTION
Got too aggressive with https://github.com/steverep/transform-async-modules-webpack-plugin/pull/41/commits/b96694da4a63967b34a690e11f7d8adef520612b.  While node doesn't care, browsers need the default property for the regenerator runtime require.